### PR TITLE
28 sidebar modifications

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -49,7 +49,6 @@ export default function DashboardPage() {
     <div className="App bg-background text-foreground">
       <LiveAPIProvider options={apiOptions}>
         <div className="streaming-console flex h-screen w-screen bg-background text-foreground">
-          <SidePanel />
           <main className="relative flex flex-col items-center justify-center flex-grow gap-4 max-w-full overflow-hidden bg-card text-card-foreground">
             <div className="absolute top-4 right-4 z-10">
               <ThemeToggle />
@@ -107,6 +106,7 @@ export default function DashboardPage() {
               {/* put your own buttons here */}
             </ControlTray>
           </main>
+          <SidePanel />
         </div>
       </LiveAPIProvider>
     </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -18,6 +18,10 @@ const SidePanel = dynamic(
   () => import("../../src/components/side-panel/SidePanel"),
   { ssr: false }
 );
+const LeftPanel = dynamic(
+  () => import("../../src/components/side-panel/LeftPanel"),
+  { ssr: false }
+);
 const Altair = dynamic(
   () =>
     import("../../src/tools/altair/Altair").then((m) => ({
@@ -49,6 +53,7 @@ export default function DashboardPage() {
     <div className="App bg-background text-foreground">
       <LiveAPIProvider options={apiOptions}>
         <div className="streaming-console flex h-screen w-screen bg-background text-foreground">
+          <LeftPanel />
           <main className="relative flex flex-col items-center justify-center flex-grow gap-4 max-w-full overflow-hidden bg-card text-card-foreground">
             <div className="absolute top-4 right-4 z-10">
               <ThemeToggle />

--- a/src/components/side-panel/LeftPanel.tsx
+++ b/src/components/side-panel/LeftPanel.tsx
@@ -44,8 +44,8 @@ export default function LeftPanel() {
   return (
     <div
       className={cn(
-        "bg-neutral-0 flex flex-col h-screen transition-all duration-200 ease-in border-r border-gray-600 text-neutral-90 font-mono text-[13px] font-normal leading-[160%]",
-        open ? "w-[270px]" : "w-[64px]"
+        "bg-neutral-0 flex flex-col h-screen transition-all duration-200 ease-in border-r border-neutral-20 text-neutral-90 font-sans text-[13px] leading-[160%] shadow-sm",
+        open ? "w-[280px]" : "w-[64px]"
       )}
     >
       {/* Header with Logo and Collapse/Expand */}
@@ -102,8 +102,9 @@ export default function LeftPanel() {
             <li>
               <button
                 className={cn(
-                  "w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
-                  active === "tasks" && "text-neutral-90 bg-neutral-20"
+                  "relative group w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
+                  active === "tasks" &&
+                    "text-neutral-90 bg-neutral-10 before:content-[''] before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-5 before:w-1 before:bg-blue-500 before:rounded"
                 )}
                 aria-label="Tasks & Reminders"
                 title="Tasks & Reminders"
@@ -115,8 +116,9 @@ export default function LeftPanel() {
             <li>
               <button
                 className={cn(
-                  "w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
-                  active === "notes" && "text-neutral-90 bg-neutral-20"
+                  "relative group w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
+                  active === "notes" &&
+                    "text-neutral-90 bg-neutral-10 before:content-[''] before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-5 before:w-1 before:bg-blue-500 before:rounded"
                 )}
                 aria-label="Notes & Journals"
                 title="Notes & Journals"
@@ -128,8 +130,9 @@ export default function LeftPanel() {
             <li>
               <button
                 className={cn(
-                  "w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
-                  active === "focus" && "text-neutral-90 bg-neutral-20"
+                  "relative group w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
+                  active === "focus" &&
+                    "text-neutral-90 bg-neutral-10 before:content-[''] before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-5 before:w-1 before:bg-blue-500 before:rounded"
                 )}
                 aria-label="Focus Mode"
                 title="Focus Mode"
@@ -141,8 +144,9 @@ export default function LeftPanel() {
             <li>
               <button
                 className={cn(
-                  "w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
-                  active === "library" && "text-neutral-90 bg-neutral-20"
+                  "relative group w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
+                  active === "library" &&
+                    "text-neutral-90 bg-neutral-10 before:content-[''] before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-5 before:w-1 before:bg-blue-500 before:rounded"
                 )}
                 aria-label="Library"
                 title="Library"
@@ -162,8 +166,9 @@ export default function LeftPanel() {
               <li>
                 <button
                   className={cn(
-                    "w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
-                    active === "tasks" && "bg-neutral-20 text-neutral-90"
+                    "relative w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
+                    active === "tasks" &&
+                      "bg-neutral-10 text-neutral-90 before:content-[''] before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-5 before:w-1 before:bg-blue-500 before:rounded"
                   )}
                   onClick={() => setActive("tasks")}
                   aria-label="Tasks & Reminders"
@@ -175,8 +180,9 @@ export default function LeftPanel() {
               <li>
                 <button
                   className={cn(
-                    "w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
-                    active === "notes" && "bg-neutral-20 text-neutral-90"
+                    "relative w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
+                    active === "notes" &&
+                      "bg-neutral-10 text-neutral-90 before:content-[''] before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-5 before:w-1 before:bg-blue-500 before:rounded"
                   )}
                   onClick={() => setActive("notes")}
                   aria-label="Notes & Journals"
@@ -188,8 +194,9 @@ export default function LeftPanel() {
               <li>
                 <button
                   className={cn(
-                    "w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
-                    active === "focus" && "bg-neutral-20 text-neutral-90"
+                    "relative w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
+                    active === "focus" &&
+                      "bg-neutral-10 text-neutral-90 before:content-[''] before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-5 before:w-1 before:bg-blue-500 before:rounded"
                   )}
                   onClick={() => setActive("focus")}
                   aria-label="Focus Mode"
@@ -201,8 +208,9 @@ export default function LeftPanel() {
               <li>
                 <button
                   className={cn(
-                    "w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
-                    active === "library" && "bg-neutral-20 text-neutral-90"
+                    "relative w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
+                    active === "library" &&
+                      "bg-neutral-10 text-neutral-90 before:content-[''] before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-5 before:w-1 before:bg-blue-500 before:rounded"
                   )}
                   onClick={() => setActive("library")}
                   aria-label="Library"
@@ -219,11 +227,11 @@ export default function LeftPanel() {
               {history.map((h) => (
                 <li key={h.id}>
                   <button
-                    className="w-full text-left rounded-md px-2 py-2 hover:bg-neutral-10"
+                    className="group w-full text-left rounded-md px-2 py-2 hover:bg-neutral-10 hover:ring-1 hover:ring-neutral-20"
                     title={h.title}
                   >
                     <div className="flex items-center gap-2">
-                      <RiHistoryLine size={16} className="text-neutral-60" />
+                      <RiHistoryLine size={16} className="text-neutral-60 group-hover:text-neutral-80" />
                       <div className="flex-1 min-w-0">
                         <div className="truncate text-[13px] text-neutral-90">{h.title}</div>
                         <div className="text-[11px] text-neutral-60">{h.subtitle}</div>
@@ -238,12 +246,12 @@ export default function LeftPanel() {
       </nav>
 
       {/* Account footer */}
-      <div className="mt-auto relative border-t border-neutral-20">
+  <div className="mt-auto relative border-t border-neutral-20 bg-neutral-0/80">
         {/* Expanded account row */}
         {open ? (
-          <div className="p-2">
+      <div className="p-2">
             <button
-              className="w-full flex items-center gap-2 rounded-md px-2 py-2 hover:bg-neutral-10 text-left"
+        className="w-full flex items-center gap-2 rounded-md px-2 py-2 hover:bg-neutral-10 text-left"
               aria-label="Account menu"
               onClick={() => setAccountOpen((v) => !v)}
             >

--- a/src/components/side-panel/LeftPanel.tsx
+++ b/src/components/side-panel/LeftPanel.tsx
@@ -1,0 +1,237 @@
+import cn from "classnames";
+import { useMemo, useState } from "react";
+import {
+  RiSidebarFoldLine,
+  RiSidebarUnfoldLine,
+  RiCheckboxCircleLine,
+  RiStickyNoteLine,
+  RiBookOpenLine,
+  RiHistoryLine,
+  RiTimerLine,
+} from "react-icons/ri";
+
+/**
+ * LeftPanel: a simple collapsible side panel (no console content)
+ * Mirrors SidePanel container styles for visual symmetry.
+ */
+export default function LeftPanel() {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState<
+    "tasks" | "notes" | "focus" | "library"
+  >("tasks");
+
+  // Placeholder history items (replace with real data when wired up)
+  const history = useMemo(
+    () => [
+      { id: "h1", title: "Quick task list", subtitle: "Today" },
+      { id: "h2", title: "Movie search session", subtitle: "Yesterday" },
+      { id: "h3", title: "Brain dump notes", subtitle: "Mon" },
+      { id: "h4", title: "Weekly journal", subtitle: "Sun" },
+      { id: "h5", title: "Focus timer test", subtitle: "Last week" },
+    ],
+    []
+  );
+
+  return (
+    <div
+      className={cn(
+        "bg-neutral-0 flex flex-col h-screen transition-all duration-200 ease-in border-r border-gray-600 text-neutral-90 font-mono text-[13px] font-normal leading-[160%]",
+        open ? "w-[270px]" : "w-[64px]"
+      )}
+    >
+      {/* Header with Logo and Collapse/Expand */}
+      <header
+        className={cn(
+          "flex items-center border-b border-neutral-20 h-12",
+          open ? "px-3 justify-between" : "px-2 justify-center"
+        )}
+      >
+        {/* Logo */}
+        <div
+          className={cn(
+            "flex items-center gap-2 transition-opacity duration-200",
+            open ? "opacity-100" : "opacity-0 pointer-events-none select-none"
+          )}
+        >
+          <div className="h-7 w-7 rounded-md bg-neutral-20 grid place-items-center text-neutral-80 text-[12px] font-bold">
+            A0
+          </div>
+          <span className="text-neutral-90 font-google-sans text-[15px] font-medium tracking-wide">
+            Agent-0
+          </span>
+        </div>
+
+        {/* Toggle Button (always visible) */}
+        {open ? (
+          <button
+            className="h-[30px] transition-transform duration-200 ease-in"
+            aria-label="Collapse left panel"
+            title="Collapse"
+            onClick={() => setOpen(false)}
+          >
+            <RiSidebarFoldLine color="#b4b8bb" />
+          </button>
+        ) : (
+          <button
+            className="h-[30px] transition-transform duration-200 ease-in"
+            aria-label="Expand left panel"
+            title="Expand"
+            onClick={() => setOpen(true)}
+          >
+            <RiSidebarUnfoldLine color="#b4b8bb" />
+          </button>
+        )}
+      </header>
+
+      {/* Main Nav */}
+      <nav className="py-2">
+        {/* Icon-only rail when collapsed */}
+        {!open && (
+          <ul className="flex flex-col items-center gap-1">
+            <li>
+              <button
+                className={cn(
+                  "w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
+                  active === "tasks" && "text-neutral-90 bg-neutral-20"
+                )}
+                aria-label="Tasks & Reminders"
+                title="Tasks & Reminders"
+                onClick={() => setActive("tasks")}
+              >
+                <RiCheckboxCircleLine size={18} />
+              </button>
+            </li>
+            <li>
+              <button
+                className={cn(
+                  "w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
+                  active === "notes" && "text-neutral-90 bg-neutral-20"
+                )}
+                aria-label="Notes & Journals"
+                title="Notes & Journals"
+                onClick={() => setActive("notes")}
+              >
+                <RiStickyNoteLine size={18} />
+              </button>
+            </li>
+            <li>
+              <button
+                className={cn(
+                  "w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
+                  active === "focus" && "text-neutral-90 bg-neutral-20"
+                )}
+                aria-label="Focus Mode"
+                title="Focus Mode"
+                onClick={() => setActive("focus")}
+              >
+                <RiTimerLine size={18} />
+              </button>
+            </li>
+            <li>
+              <button
+                className={cn(
+                  "w-10 h-9 rounded-md grid place-items-center text-neutral-70 hover:bg-neutral-10",
+                  active === "library" && "text-neutral-90 bg-neutral-20"
+                )}
+                aria-label="Library"
+                title="Library"
+                onClick={() => setActive("library")}
+              >
+                <RiBookOpenLine size={18} />
+              </button>
+            </li>
+          </ul>
+        )}
+
+        {/* Full list when expanded */}
+        {open && (
+          <div className="px-2">
+            <div className="text-[11px] uppercase tracking-wide text-neutral-60 px-2 py-2">Workspace</div>
+            <ul className="flex flex-col gap-1">
+              <li>
+                <button
+                  className={cn(
+                    "w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
+                    active === "tasks" && "bg-neutral-20 text-neutral-90"
+                  )}
+                  onClick={() => setActive("tasks")}
+                  aria-label="Tasks & Reminders"
+                >
+                  <RiCheckboxCircleLine size={18} />
+                  <span className="text-[13px]">Tasks & Reminders</span>
+                </button>
+              </li>
+              <li>
+                <button
+                  className={cn(
+                    "w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
+                    active === "notes" && "bg-neutral-20 text-neutral-90"
+                  )}
+                  onClick={() => setActive("notes")}
+                  aria-label="Notes & Journals"
+                >
+                  <RiStickyNoteLine size={18} />
+                  <span className="text-[13px]">Notes & Journals</span>
+                </button>
+              </li>
+              <li>
+                <button
+                  className={cn(
+                    "w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
+                    active === "focus" && "bg-neutral-20 text-neutral-90"
+                  )}
+                  onClick={() => setActive("focus")}
+                  aria-label="Focus Mode"
+                >
+                  <RiTimerLine size={18} />
+                  <span className="text-[13px]">Focus Mode</span>
+                </button>
+              </li>
+              <li>
+                <button
+                  className={cn(
+                    "w-full flex items-center gap-2 rounded-md px-2 py-2 text-neutral-80 hover:bg-neutral-10",
+                    active === "library" && "bg-neutral-20 text-neutral-90"
+                  )}
+                  onClick={() => setActive("library")}
+                  aria-label="Library"
+                >
+                  <RiBookOpenLine size={18} />
+                  <span className="text-[13px]">Library</span>
+                </button>
+              </li>
+            </ul>
+
+            {/* History */}
+            <div className="text-[11px] uppercase tracking-wide text-neutral-60 px-2 py-2 mt-3">History</div>
+            <ul className="flex flex-col gap-1 max-h-[45vh] overflow-y-auto pr-1">
+              {history.map((h) => (
+                <li key={h.id}>
+                  <button
+                    className="w-full text-left rounded-md px-2 py-2 hover:bg-neutral-10"
+                    title={h.title}
+                  >
+                    <div className="flex items-center gap-2">
+                      <RiHistoryLine size={16} className="text-neutral-60" />
+                      <div className="flex-1 min-w-0">
+                        <div className="truncate text-[13px] text-neutral-90">{h.title}</div>
+                        <div className="text-[11px] text-neutral-60">{h.subtitle}</div>
+                      </div>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </nav>
+
+      {/* Footer (collapsed rail shows nothing) */}
+      {open && (
+        <footer className="mt-auto p-2 border-t border-neutral-20 text-[11px] text-neutral-60">
+          <div className="px-1">v0.1 · Personal workspace</div>
+        </footer>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new collapsible left-side navigation panel (`LeftPanel`) to the dashboard layout, improving workspace navigation and user account access. The main dashboard layout is updated to use both the new `LeftPanel` and the existing `SidePanel`, creating a more visually balanced and user-friendly interface.

**Dashboard Layout Changes**
* The dashboard layout now includes both `LeftPanel` (on the left) and `SidePanel` (on the right), replacing the previous single side panel setup for improved symmetry and navigation. (`app/dashboard/page.tsx`) [[1]](diffhunk://#diff-e16c1c1133d5d72341ada507f3e06fa37dd79de574403f158159ff934f9b5013R21-R24) [[2]](diffhunk://#diff-e16c1c1133d5d72341ada507f3e06fa37dd79de574403f158159ff934f9b5013L52-R56) [[3]](diffhunk://#diff-e16c1c1133d5d72341ada507f3e06fa37dd79de574403f158159ff934f9b5013R114)

**New LeftPanel Component**
* Added new `LeftPanel` component with collapsible functionality, workspace navigation (tasks, notes, focus, library), a history section, and an account menu with sign-in/sign-out options. (`src/components/side-panel/LeftPanel.tsx`)

**Navigation and Account Features**
* The navigation adapts between icon-only (collapsed) and full-text (expanded) modes, and the account menu supports sign-in, sign-out, and account management actions using Clerk authentication. (`src/components/side-panel/LeftPanel.tsx`)